### PR TITLE
Added mention.everyone condition check to on_message()

### DIFF
--- a/bot/events.py
+++ b/bot/events.py
@@ -43,7 +43,8 @@ async def on_disconnect() -> None:
 
 @bot.event
 async def on_message(message: Message) -> None:
-  if message.author == bot.user:
+  #Exit function if Hooter is sending message or if everyone is mentioned
+  if message.author == bot.user or message.mention_everyone:
     return
 
   username: str = str(message.author)
@@ -51,6 +52,7 @@ async def on_message(message: Message) -> None:
   channel: str = str(message.channel)
 
   logger.info(f"[{channel}] {username}: {user_message}")
+  logger.info(f"the last message was: {message}")
 
   if bot.user.mentioned_in(message):
     user_message = user_message.replace(f'<@!{bot.user.id}>', '').strip()


### PR DESCRIPTION
Before fix, Hooter bot was responding to messages @here and @everyone, which was not a desired behavior.

Confirmed that @here and @everyone was effectively mentioning Hooter because mentioned_in() function first checks for the mention.everyone condition.

Expanded first condition check in on_message() so that if message comes from Hooter or if everyone is mentioned in the message, the function is exited.

Before (Hooter replying to @here):
<img width="639" height="594" alt="image" src="https://github.com/user-attachments/assets/05fa8baa-d226-438e-9041-5457004b580f" />

After (Hooter not replying to @here or @everyone, but still replying when mentioned directly):
<img width="620" height="642" alt="image" src="https://github.com/user-attachments/assets/29dd2684-2ac4-40a6-9a34-8a248a3c7e1d" />
